### PR TITLE
print newline after error message

### DIFF
--- a/R/expectation.r
+++ b/R/expectation.r
@@ -29,7 +29,7 @@ expectation_error <- function(error, calls) {
   if (length(calls) > 0) {
     traceback <- create_traceback(calls)
     user_calls <- paste0(traceback, collapse = "\n")
-    msg <- paste0(msg, user_calls)
+    msg <- paste0(msg, "\n", user_calls)
   } else {
     # Need to remove trailing newline from error message to be consistent
     # with other messages


### PR DESCRIPTION
With some tests, the error message is joined with the first line of the traceback. I'm not sure if the fix is universally applicable, or if we need to check if `msg` already ends with a newline.
